### PR TITLE
🚸 (ux) Balance white space around eyebrow

### DIFF
--- a/src/sass/layouts/_article.scss
+++ b/src/sass/layouts/_article.scss
@@ -111,7 +111,7 @@
 
     @include mq($bkpt-articles--3-cols) {
       grid-column: 3 / span 1;
-      padding-top: pxRem(60px);
+      padding-top: 2rem;
     }
   }
 


### PR DESCRIPTION
@nataliasite asked me if there was a way to make the eyebrow a little less prominent on the landing blog post, so I updated it's top padding so that it's visually balanced with the bottom padding.