### PR TITLE
🚑 (code) Allow robots access to the site

### DIFF
--- a/templates/_layouts/_wrapper.html
+++ b/templates/_layouts/_wrapper.html
@@ -2,14 +2,12 @@
 <html lang="{{ locale.code }}" dir="{{ locale.dir }}">
   <head>
     <meta charset="UTF-8" />
-    <!-- TODO: Remove when ready to launch. Issue #281 -->
-    <meta name="robots" content="none" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
 
     <title>{% if title %}{{ title }} | {% endif %}chromeOS.dev</title>
     <meta name="Description" content="{{ metadesc }}" />
-    <meta name="theme-color" content="#2196f3" />
+    <meta name="theme-color" content="#1a73e8" />
     <link rel="icon" type="image/png" href="/images/icons/favicon.png" />
     <link rel="apple-touch-icon" href="/images/icons/pwa/icon-192x192.png" />
 


### PR DESCRIPTION
This is the final launch prep item we need! It allows robots, like Google Search, to crawl our site!
Also aligns the theme color with what's in our manifest.
