### PR TITLE
🚑 (ux) Fix layout break with code blocks

### DIFF
--- a/src/sass/components/_code-figure.scss
+++ b/src/sass/components/_code-figure.scss
@@ -1,4 +1,6 @@
 .code-figure {
+  display: grid;
+
   &--caption {
     margin-bottom: 0.25rem;
   }

--- a/src/sass/components/_pre.scss
+++ b/src/sass/components/_pre.scss
@@ -25,7 +25,6 @@
     line-height: 1.45;
     outline: 0;
     padding: 1rem;
-    white-space: pre;
   }
 }
 

--- a/src/sass/components/_pre.scss
+++ b/src/sass/components/_pre.scss
@@ -25,6 +25,9 @@
     line-height: 1.45;
     outline: 0;
     padding: 1rem;
+    white-space: pre;
+    word-break: normal;
+    word-wrap: normal;
   }
 }
 


### PR DESCRIPTION
Code blocks with `pre` white spacing were overflowing our small layout; making the parent they'
re wrapped in `display: grid` restricts their growth and properly overflows as needed. Also fixes word breaking in Safari for n
on-pre-wrapped code.