### PR TITLE
🔥 (ux) Remove updated page snackbar

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import dynamicImportPolyfill from 'dynamic-import-polyfill';
-import { getData } from './lib/data';
 import { preferences } from 'service-worker-i18n-redirect/preferences';
 import { MainNavigation } from './components/nav';
 import { CookieDisclaimer } from './components/cookie-disclaimer';
@@ -148,25 +147,6 @@ if ('serviceWorker' in navigator) {
     } catch (e) {
       // log('Registration failed 😫');
       // log(e);
-    }
-  });
-
-  navigator.serviceWorker.addEventListener('message', async e => {
-    if (e.data.meta === 'workbox-broadcast-update') {
-      const { cacheName, updatedURL } = e.data.payload;
-      const location = window.location.pathname.replace(/\/$/, '');
-      if (cacheName === 'pages-cache' && new URL(updatedURL).pathname === location) {
-        const language = await preferences.get('lang');
-        const microcopy = await getData('microcopy', language);
-        const { SnackbarArea } = await import('./components/snackbar.js');
-        const snackbar = new SnackbarArea();
-        snackbar.add(microcopy.sw.page, {
-          text: microcopy.sw.refresh,
-          cb() {
-            window.location.reload();
-          },
-        });
-      }
     }
   });
 }

--- a/src/sw.js
+++ b/src/sw.js
@@ -19,7 +19,6 @@ import { CacheFirst, StaleWhileRevalidate, NetworkFirst } from 'workbox-strategi
 import { ExpirationPlugin } from 'workbox-expiration';
 import { precacheAndRoute, matchPrecache } from 'workbox-precaching';
 import { registerRoute, setCatchHandler } from 'workbox-routing';
-import { BroadcastUpdatePlugin } from 'workbox-broadcast-update';
 import * as googleAnalytics from 'workbox-google-analytics';
 import { i18nHandler } from 'service-worker-i18n-redirect';
 import { preferences } from 'service-worker-i18n-redirect/preferences';
@@ -39,7 +38,6 @@ const htmlCachingStrategy = new StaleWhileRevalidate({
     new CacheableResponsePlugin({
       statuses: [200],
     }),
-    new BroadcastUpdatePlugin(),
   ],
 });
 


### PR DESCRIPTION
Because of how Workbox determines if a page has been updated, this is mostly filled with false
positives for our particular site. Removing this as it's creating a poor UX for our users.