### PR TITLE
🐛 (ux) Fix landing page eyebrow alignment

### DIFF
--- a/src/sass/layouts/_tech-detail.scss
+++ b/src/sass/layouts/_tech-detail.scss
@@ -90,9 +90,14 @@
   &__eyebrow-wrapper {
     background-color: var(--white);
     border-top: 0.5rem solid var(--blue-600);
-    padding-left: $spacing;
-    padding-right: $spacing;
+    padding-left: $inline-padding;
+    padding-right: $block-padding;
     padding-top: 2rem;
+
+    @include mq($bkpt-tech-details--2-cols) {
+      padding-left: $spacing;
+      padding-right: $spacing;
+    }
   }
 
   &__header {


### PR DESCRIPTION
As brought up in our chat, there's a mis-alignment issue with landing page titles when small. This resolves that.

![Mis-aligned landing pages](https://user-images.githubusercontent.com/377188/90183139-9c850a00-dd78-11ea-8112-fc75a12ce372.png)
