### PR TITLE
🔧 (tests) Update Lighthouse config

### DIFF
--- a/.github/actions/message/message.js
+++ b/.github/actions/message/message.js
@@ -145,9 +145,12 @@ function buildLighthouseResults(input, date) {
 
   for (const [key, value] of Object.entries(lh)) {
     if (value.results.length) {
-      message += `[${key.replace(input.url, '')} report](${value.report})\n|audit|high|expected|values|\n| :---: | :---: | :---: | :---: |\n`;
-      for (const result of value.results) {
-        message += `|${result.auditProperty}|${result.actual * 100}|${result.expected * 100}|${result.values.map(i => i * 100).join(', ')}|\n`;
+      message += `[${key.replace(input.url, '')} report](${value.report})`;
+      if (value.results.length) {
+        message += '\n|audit|high|expected|values|\n| :---: | :---: | :---: | :---: |\n';
+        for (const result of value.results) {
+          message += `|${result.auditProperty}|${result.actual * 100}|${result.expected * 100}|${result.values.map(i => i * 100).join(', ')}|\n`;
+        }
       }
       message += '\n';
     }

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -99,12 +99,13 @@ jobs:
       - name: Lighthouse Audit
         id: lighthouse
         uses: treosh/lighthouse-ci-action@v3
-        continue-on-error: true
         with:
           urls: |
-            https://cros-staging.web.app/en
             ${{ steps.deploy.outputs.url }}/en
             ${{ steps.deploy.outputs.url }}/es
+            ${{ steps.deploy.outputs.url }}/en/linux
+            ${{ steps.deploy.outputs.url }}/en/news
+            ${{ steps.deploy.outputs.url }}/en/android/design
           configPath: ./.lighthouserc.yml
           temporaryPublicStorage: true
           uploadArtifacts: true

--- a/.lighthouserc.yml
+++ b/.lighthouserc.yml
@@ -5,7 +5,7 @@ ci:
     assertions:
       categories:performance:
         - error
-        - minScore: 0.9
+        - minScore: 0.8
       categories:accessibility:
         - error
         - minScore: 0.9
@@ -14,8 +14,7 @@ ci:
         - minScore: 0.9
       categories:seo:
         - error
-        # TODO: Set back to 85 for launch. Issue #281
-        - minScore: 0.80
+        - minScore: 0.9
       categories:pwa:
         - error
         - minScore: 0.9


### PR DESCRIPTION
Increases SEO min, sets Performance min to 80, tests more pages, makes sure Lighthouse results table
only shows if there are results
