### PR TITLE
🐛 (code) Ensure shortlinks route to network only.

### DIFF
--- a/src/sw.js
+++ b/src/sw.js
@@ -15,7 +15,7 @@
  */
 /* global importScripts, languages  */
 import { CacheableResponsePlugin } from 'workbox-cacheable-response';
-import { CacheFirst, StaleWhileRevalidate, NetworkFirst } from 'workbox-strategies';
+import { CacheFirst, StaleWhileRevalidate, NetworkFirst, NetworkOnly } from 'workbox-strategies';
 import { ExpirationPlugin } from 'workbox-expiration';
 import { precacheAndRoute, matchPrecache } from 'workbox-precaching';
 import { registerRoute, setCatchHandler } from 'workbox-routing';
@@ -29,6 +29,9 @@ importScripts('/js/languages.js');
 precacheAndRoute(self.__WB_MANIFEST);
 
 googleAnalytics.initialize();
+
+// Short links are read live from a database and should be a network only request
+registerRoute(({ url }) => url.pathname.startsWith('/l/'), new NetworkOnly());
 
 // Handle navigation requests with htmlHandler.
 const htmlCachingStrategy = new StaleWhileRevalidate({


### PR DESCRIPTION
This modifies the workbox router to ensure that shortlinks hit the
network and not the precached content. This ensures that these requests
are always validated by the database first.
