### PR TITLE
Corrected special character apostrophes in docs

### DIFF
--- a/pages/en/publish/pwa-play-billing.md
+++ b/pages/en/publish/pwa-play-billing.md
@@ -40,13 +40,13 @@ The Digital Goods API was designed to be compatible with various browsers and di
 
 ```js
 if ('getDigitalGoodsService' in window) {
-	// Digital Goods API is supported!
-	const service = await window.getDigitalGoodsService('https://play.google.com/billing');
-	if (service) {
-		// Google Play Billing service is available!
-	} else {
-		console.log('Google Play Billing is not available');
-	}
+  // Digital Goods API is supported!
+  const service = await window.getDigitalGoodsService('https://play.google.com/billing');
+  if (service) {
+    // Google Play Billing service is available!
+  } else {
+    console.log('Google Play Billing is not available');
+  }
 }
 ```
 
@@ -145,16 +145,17 @@ Learn more about the different proration modes in the Google Play Billing Librar
 The usage of these additional fields will look something like this:
 
 ```js
-const paymentMethod = [{
-	supportedMethods: 'https://play.google.com/billing',
-	data: {
-		sku: item.itemId,
-		oldSku: oldPurchase.itemId,
-		purchaseToken: oldPurchase.purchaseToken,
-		prorationMode: 'immediateAndChargeProratedPrice',
-	}
-}];
-
+const paymentMethod = [
+  {
+    supportedMethods: 'https://play.google.com/billing',
+    data: {
+      sku: item.itemId,
+      oldSku: oldPurchase.itemId,
+      purchaseToken: oldPurchase.purchaseToken,
+      prorationMode: 'immediateAndChargeProratedPrice',
+    },
+  },
+];
 ```
 
 Here, `item` is the `ItemDetails` of the new subscription the user is trying to upgrade or downgrade to, and `oldPurchase` is the `PurchaseDetails` of the user’s current subscription.

--- a/pages/en/publish/pwa-play-billing.md
+++ b/pages/en/publish/pwa-play-billing.md
@@ -45,7 +45,7 @@ if ('getDigitalGoodsService' in window) {
 	if (service) {
 		// Google Play Billing service is available!
 	} else {
-		console.log(‘Google Play Billing is not available’);
+		console.log('Google Play Billing is not available');
 	}
 }
 ```
@@ -146,7 +146,7 @@ The usage of these additional fields will look something like this:
 
 ```js
 const paymentMethod = [{
-	supportedMethods: ‘https://play.google.com/billing’,
+	supportedMethods: 'https://play.google.com/billing',
 	data: {
 		sku: item.itemId,
 		oldSku: oldPurchase.itemId,
@@ -173,7 +173,7 @@ The Digital Goods API requires a purchase to be acknowledged with a `PurchaseTyp
 | -------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | in-app product | onetime      | When a user should only buy a product once and will own it forever (non-consumable item), or when a user can only own one instance of it at a time (needs to be consumed before they can purchase another). |
 |                | repeatable   | When a user can buy and own multiples of a product (consumable item).                                                                                                                                       |
-| subscription   | onetime      | Subscriptions are always acknowledged as ‘onetime’ because a user should only have at most one instance of each subscription.                                                                               |
+| subscription   | onetime      | Subscriptions are always acknowledged as 'onetime' because a user should only have at most one instance of each subscription.                                                                               |
 
 Call `acknowledge()` with the `purchaseToken` string that was returned earlier by the payment response in the `data` member, along with the appropriate purchase type.
 

--- a/pages/en/web/desktop-progressive-web-apps.md
+++ b/pages/en/web/desktop-progressive-web-apps.md
@@ -58,8 +58,8 @@ Almost all Chrome OS devices support touch and many support styluses, too, so yo
 If you’re building an app that has users drawing with their fingers or styluses, keeping latency between their input and your output fast enough to feel fluid has historically been difficult. When building these kinds of [Canvas API](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API) powered apps for Chrome OS, we recommend using the `desynchronized` hint for `canvas.getContext()` to provide [low-latency rendering](https://developers.google.com/web/updates/2019/05/desynchronized). To use the `desynchronized` hint for a canvas, do the following:
 
 ```js
-const canvas = document.createElement(‘canvas’); // or select one from the DOM
-const ctx = canvas.getContext(‘2d’, {
+const canvas = document.createElement('canvas'); // or select one from the DOM
+const ctx = canvas.getContext('2d', {
   desynchronized: true,
   // Other options here…
 });

--- a/pages/es/web/desktop-progressive-web-apps.md
+++ b/pages/es/web/desktop-progressive-web-apps.md
@@ -55,8 +55,8 @@ Casi todos los dispositivos Chrome OS son compatibles con el tacto y muchos comp
 Si está creando una aplicación que hace que los usuarios dibujen con los dedos o con lápices, mantener la latencia entre su entrada y su salida lo suficientemente rápido como para sentir fluidez históricamente ha sido difícil. Al compilar este tipo de aplicaciones de [Canvas API](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API) para Chrome OS, recomendamos utilizar la sugerencia `desynchronized` para `canvas.getContext()` para proporcionar [una representación de baja latencia](https://developers.google.com/web/updates/2019/05/desynchronized) . Para usar la sugerencia `desynchronized` para un lienzo, haga lo siguiente:
 
 ```js
-const canvas = document.createElement(‘canvas’); // or select one from the DOM
-const ctx = canvas.getContext(‘2d’, {
+const canvas = document.createElement('canvas'); // or select one from the DOM
+const ctx = canvas.getContext('2d', {
   desynchronized: true,
   // Other options here…
 });


### PR DESCRIPTION
**Please describe what your Pull Request does**

Fixes up special character quotes to be single code-style apostrophes in a few docs code snippets, mostly on https://chromeos.dev/en/publish/pwa-play-billing.

**Please tag each issue this Pull Request resolves**

- ~Resolves #~
