### PR TITLE
🐛 (general) Swap to new newsletter signup URL

### DIFF
--- a/pages/en/_data/newsletter.yml
+++ b/pages/en/_data/newsletter.yml
@@ -1,6 +1,6 @@
 settings:
   name: newsletter-sign-up
-  endpoint: https://services.google.com/fb/submissions/chromeos-newsletter/
+  endpoint: https://services.google.com/fb/submissions/chromeos-newsletter-v2/
 content:
   title: Get Chrome OS developer news and updates direct to you
   copy: Sign up for the latest news, tips, releases, updates, and more on Chrome OS.

--- a/pages/es/_data/newsletter.yml
+++ b/pages/es/_data/newsletter.yml
@@ -1,6 +1,6 @@
 settings:
   name: newsletter-sign-up
-  endpoint: https://services.google.com/fb/submissions/chromeos-newsletter/
+  endpoint: https://services.google.com/fb/submissions/chromeos-newsletter-v2/
 content:
   title: Reciba noticias y actualizaciones para desarrolladores de Chrome OS directamente
   copy: Regístrese para recibir las últimas noticias, consejos, lanzamientos, actualizaciones y más sobre Chrome OS.


### PR DESCRIPTION
Previous URL has a back-end integration bug that can only be solved by swapping to a new instance.