### PR TITLE
🐛(build) Fix PostHTML class and attribute helpers

### DIFF
--- a/lib/helpers/posthtml.js
+++ b/lib/helpers/posthtml.js
@@ -32,11 +32,12 @@ function setAttribute(a, v) {
    * @return {PostHTMLNode}
    */
   return function setAttributeOnNode(node) {
-    if (node.attrs && node.attrs[a]) {
-      node.attrs[a] = v;
-    } else {
-      node.attrs = { [a]: v };
+    if (!node.attrs) {
+      node.attrs = {};
     }
+
+    node.attrs[a] = v;
+
     return node;
   };
 }
@@ -58,10 +59,14 @@ function addClass(className) {
     }
 
     for (const item of working) {
+      if (!item.attrs) {
+        item.attrs = {};
+      }
+
       if (item.attrs?.class) {
         item.attrs.class += ` ${className}`;
       } else {
-        item.attrs = { class: className };
+        item.attrs.class = className;
       }
     }
 


### PR DESCRIPTION
Previously overrode attributes if the class or the attribute didn't exist; now checks to see if attrs exists and if not, sets it to an object that can then be manipulated as needed

Resolves #180 
