### PR TITLE
🐎(build) Move to JSON format for image sizes

### DIFF
--- a/lib/transforms/google-storage-images.js
+++ b/lib/transforms/google-storage-images.js
@@ -1,6 +1,5 @@
 const { extname } = require('path');
 const fetch = require('node-fetch');
-const imageSize = require('image-size');
 const sizeMap = {};
 
 const imageSizes = [250, 400, 550, 700, 850, 1000, 1150, 1300, 1450, 1500];
@@ -13,11 +12,10 @@ const imageSizes = [250, 400, 550, 700, 850, 1000, 1150, 1300, 1450, 1500];
 async function getImageSize(url) {
   // TODO: Add @11ty/eleventy-cache-assets in? This will let us cache locally, maybe for images too?
   try {
-    const img = await fetch(`${url}?fit=fillmax&w=100`).then(res => res.buffer());
-    const size = imageSize(img);
+    const img = await fetch(`${url}?fm=json`).then(res => res.json());
     sizeMap[url] = {
-      height: size.height * 15,
-      width: size.width * 15,
+      height: img.PixelWidth,
+      width: img.PixelHeight,
     };
   } catch (e) {
     sizeMap[url] = {


### PR DESCRIPTION
Updates build to grab JSON with full image info for height/width instead of relying on a proxy image