### PR TITLE
🐛(build) Upgrade to newer Firebase action

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -162,7 +162,7 @@ jobs:
         run: |
           npm install --prefix functions
       - name: Deploy to Firebase
-        uses: w9jds/firebase-action@v1.3.0
+        uses: w9jds/firebase-action@v2.0.0
         with:
           args: deploy
         env:


### PR DESCRIPTION
The current action is failing because the version of Node and the version of Firebase Tools are incompatible with each other. Trying an upgrade to the latest version of the Deploy action to see if that'll fix it.