### PR TITLE
🐛(site) Change page cache name

### DIFF
--- a/site/sw.js
+++ b/site/sw.js
@@ -36,7 +36,7 @@ importScripts('/js/_data/_languages_.js');
  */
 // Long-lived HTML gets cached w/a Stale While Revalidate strategy
 const cacheHTMLStrategy = new StaleWhileRevalidate({
-  cacheName: 'pages-cache',
+  cacheName: 'page-cache',
   plugins: [
     new CacheableResponsePlugin({
       statuses: [200],
@@ -49,7 +49,7 @@ const cacheHTMLStrategy = new StaleWhileRevalidate({
 
 // Short-lived HTML gets cached w/a Network First strategy
 const liveHTMLStrategy = new NetworkFirst({
-  cacheName: 'pages-cache',
+  cacheName: 'page-cache',
   networkTimeoutSeconds: 2,
   plugins: [
     new CacheableResponsePlugin({


### PR DESCRIPTION
The Stale While Revalidate navigation cache has old stuff in it, but the precache that had the assets was deleted, so pages are loading entirely without assets. Changing cache names ensures that users will hit this without anything in cache and not have that problem.