### PR TITLE
🐛 Fix PR title checker to allow dashes, dots, numbers, and commas

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -4,11 +4,11 @@
     "color": "#db2780"
   },
   "CHECKS": {
-    "regexp": "^(🐎|🐛|🆕|📝|♻️|📌|💎){1}(\\((site|functions|build|tests|content)\\))? {1}(\\w|\\s)*$"
+    "regexp": "^(🐎|🐛|🆕|📝|♻️|📌|💎){1}(\\((site|functions|build|tests|content)\\))? {1}\\w(\\w|\\s|\\d|.|\\-)*$"
   },
   "MESSAGES": {
     "success": "All OK",
-    "failure": "Please make sure your PR title matches the following format: 🐎|🐛|🆕|📝|♻️|📌|💎(site|functions|build|tests|content) title",
+    "failure": "Please make sure your PR title matches the following format: 🐎|🐛|🆕|📝|♻️|📌|💎(site|functions|build|tests|content) title. Title can contain letters, spaces, numbers, dashes and dots, and must start with a letter",
     "notice": ""
   }
 }

--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -4,11 +4,11 @@
     "color": "#db2780"
   },
   "CHECKS": {
-    "regexp": "^(🐎|🐛|🆕|📝|♻️|📌|💎){1}(\\((site|functions|build|tests|content)\\))? {1}\\w(\\w|\\s|\\d|.|\\-)*$"
+    "regexp": "^(🐎|🐛|🆕|📝|♻️|📌|💎){1}(\\((site|functions|build|tests|content)\\))? {1}\\w(\\w|\\s|\\d|.|,|\\-)*$"
   },
   "MESSAGES": {
     "success": "All OK",
-    "failure": "Please make sure your PR title matches the following format: 🐎|🐛|🆕|📝|♻️|📌|💎(site|functions|build|tests|content) title. Title can contain letters, spaces, numbers, dashes and dots, and must start with a letter",
+    "failure": "Please make sure your PR title matches the following format: 🐎|🐛|🆕|📝|♻️|📌|💎(site|functions|build|tests|content) title. Title can contain letters, spaces, numbers, dashes, commas, and dots, and must start with a letter",
     "notice": ""
   }
 }


### PR DESCRIPTION
Noticed on #192 that our PR title checker doesn't allow numbers or dots in titles. This updates that to include those and dashes, and improves the error message to spell that out.