### PR TITLE
🆕 Add commit message config for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: '📌 '
+  - package-ecosystem: npm
+    directory: /functions
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: '📌(functions) '


### PR DESCRIPTION
This [looks like](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates) it should configure the titles of Dependabot PRs to follow our conventions