### PR TITLE
📌(build) Pin AVA to current major version for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
       - dependency-name: node-fetch
         update-types:
           - version-update:semver-major
+      - dependency-name: ava
+        update-types:
+          - version-update:semver-major
       - dependency-name: unified-lint-rule
         update-types:
           - version-update:semver-major


### PR DESCRIPTION
Pins AVA to current major version (3.0) because updating to 4.0 would require changing our package type to "module" and break the rest of our build. We can revisit this if we revisit testing in the future.