### PR TITLE
🐛(site) Fix style guide generation

### DIFF
--- a/lib/filters/component-has-docs.js
+++ b/lib/filters/component-has-docs.js
@@ -21,7 +21,7 @@
  * @return {object|false} Either a found item, or false.
  */
 function componentHasDocs(component, collection) {
-  const item = collection.filter((c) => `${c.fileSlug}.html` === component);
+  const item = collection.filter((c) => `${c.fileSlug}.njk` === component);
   return item.length > 0 ? item[0] : false;
 }
 

--- a/site/_data/components.js
+++ b/site/_data/components.js
@@ -17,7 +17,6 @@
 
 const fs = require('fs');
 const path = require('path');
-const config = require('config');
 const glob = require('glob');
 
 const docsRegex = new RegExp(/(?:<!--\s*?{#)(.*?)(?=#}\s*?-->)/s);
@@ -25,8 +24,8 @@ const macroRegex = new RegExp(/{%\s+?macro\s+?(\w*?)\s*?\((.*?)\)/);
 
 module.exports = function () {
   const components = {};
-  const basePath = path.join(process.cwd(), config.folders.templates, config.folders.includes);
-  const items = glob.sync(path.join(basePath, '**/*.html'));
+  const basePath = path.join(__dirname, '../_components');
+  const items = glob.sync(path.join(basePath, '**/*.njk'));
 
   for (const component of items) {
     const file = fs.readFileSync(component, 'utf-8');

--- a/site/_layouts/style-guide.njk
+++ b/site/_layouts/style-guide.njk
@@ -5,7 +5,7 @@ layout: _wrapper
 {% from 'component-preview.njk' import componentPreview %} {% set goBack = { url: 'style-guide', text: microcopy.breadcrumbs.replace('((t))', microcopy.styleGuide.title) } %} {% from 'icon.njk' import icon %}
 
 <article class="style-guide style-guide--component">
-  {% set filename = page.fileSlug + '.html' %} {% set component = components[filename] %}
+  {% set filename = page.fileSlug + '.njk' %} {% set component = components[filename] %}
   <header class="style-guide__header">
     <a class="cta cta--back" href="/{{locale.code}}/{{ goBack.url }}">{{ goBack.text }}</a>
     <h1 class="type--h2">{{title}}</h1>


### PR DESCRIPTION
Component folder was moved, and files were changed from .html to .njk, necessitating updating our automatic generation

- Resolves #302
