### PR TITLE
🐛(build) Resolve Stylelint errors in redesign/2022

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -17,7 +17,7 @@
     "function-no-unknown": [
       true,
       {
-        "ignoreFunctions": ["pxRem", "pxEm", "math.div", "nth", "map-get"]
+        "ignoreFunctions": ["pxRem", "pxEm", "generateScaling", "math.percentage", "math.div", "nth", "map-get"]
       }
     ],
     "function-url-quotes": "always",

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -17,7 +17,7 @@
     "function-no-unknown": [
       true,
       {
-        "ignoreFunctions": ["pxRem", "pxEm", "generateScaling", "math.percentage", "math.div", "nth", "map-get"]
+        "ignoreFunctions": ["pxRem", "pxEm", "generateScaling", "if", "pxCast", "unquote", "unitless", "math.percentage", "math.div", "nth", "map-get"]
       }
     ],
     "function-url-quotes": "always",

--- a/site/sass/globals/_functions.scss
+++ b/site/sass/globals/_functions.scss
@@ -18,11 +18,13 @@
   @param {boolean} $rem (optional) - Cast the provided px length or unitless number to a rem. When false, casts to em instead.
 */
 @function pxCast($length, $rem: true) {
+  /* stylelint-disable function-no-unknown */
   @if unitless($length) and $length != 0 {
     @error 'pxCast: $length is unitless and non-zero.';
   }
   $casted: if(unitless($length), $length * 1px, $length);
   @return if($rem, pxRem($casted), pxEm($casted));
+  /* stylelint-enable function-no-unknown */
 }
 
 //  @desc Scale a value from one screen width to another based on the difference between the minimum
@@ -36,6 +38,7 @@
 //  }
 //  @returns clamp($min-value, <responsive-value>, $max-value)
 @function generateScaling($widths, $values, $rem: true) {
+  /* stylelint-disable function-no-unknown */
   $params: (
     'min-width': pxCast(nth($widths, 1), $rem),
     'max-width': pxCast(nth($widths, 2), $rem),
@@ -54,4 +57,5 @@
 
   $responsive-value: unquote('#{$min-value - ($min-width * $rate)} + #{100vw * $rate}');
   @return clamp($min-value, $responsive-value, $max-value);
+  /* stylelint-enable function-no-unknown */
 }

--- a/site/sass/globals/_functions.scss
+++ b/site/sass/globals/_functions.scss
@@ -18,13 +18,11 @@
   @param {boolean} $rem (optional) - Cast the provided px length or unitless number to a rem. When false, casts to em instead.
 */
 @function pxCast($length, $rem: true) {
-  /* stylelint-disable function-no-unknown */
   @if unitless($length) and $length != 0 {
     @error 'pxCast: $length is unitless and non-zero.';
   }
   $casted: if(unitless($length), $length * 1px, $length);
   @return if($rem, pxRem($casted), pxEm($casted));
-  /* stylelint-enable function-no-unknown */
 }
 
 //  @desc Scale a value from one screen width to another based on the difference between the minimum
@@ -38,7 +36,6 @@
 //  }
 //  @returns clamp($min-value, <responsive-value>, $max-value)
 @function generateScaling($widths, $values, $rem: true) {
-  /* stylelint-disable function-no-unknown */
   $params: (
     'min-width': pxCast(nth($widths, 1), $rem),
     'max-width': pxCast(nth($widths, 2), $rem),
@@ -57,5 +54,4 @@
 
   $responsive-value: unquote('#{$min-value - ($min-width * $rate)} + #{100vw * $rate}');
   @return clamp($min-value, $responsive-value, $max-value);
-  /* stylelint-enable function-no-unknown */
 }


### PR DESCRIPTION
Linting rule changes introduced within the `main` branch caused Stylelint errors within the pre-commit hook. Adds `generateScaling` and `math.percentage`  Sass functions to Stylelint's `ignoreFunctions` in anticipation of their usage.

I opted to ignore `function-no-unknown` within bodies of the `pxCast` and `generateScaling` functions instead of adding the functions in question to `ignoreFunctions` since I don't expect `if`, `pxCast`, `unitless`, or `unquote` to be used elsewhere.

- Resolves #328 
