### PR TITLE
💎(site) Add New Design to Article Page Right Sidebar

### DIFF
--- a/site/_components/app-info.njk
+++ b/site/_components/app-info.njk
@@ -9,8 +9,8 @@
 <figure class="app-info">
   <img class="app-info__logo" src="{{app.logo}}" aria-hidden="true" alt="" />
   <figcaption class="app-info__copy-wrapper">
-    <p class="type--h5">{{app.name}}</p>
-    <p class="app-info__company">{{app.company}}</p>
+    <p class="type--h6">{{app.name}}</p>
+    <p class="type--small">{{app.company}}</p>
   </figcaption>
 </figure>
 {%- endmacro %}

--- a/site/_components/authors-list.njk
+++ b/site/_components/authors-list.njk
@@ -8,10 +8,12 @@
 
  #}-->
 {% from 'author.njk' import author as authorMacro %} {% macro authorsList(label, authors, contributors, microcopy) -%}
-<span class="authors-list__label type--label">{{ label }}</span>
-<ul class="authors-list">
-  {% for author in authors %}
-  <li class="authors-list__author">{{authorMacro(contributors[author], microcopy.author.alt, author)}}</li>
-  {% endfor %}
-</ul>
+<section>
+  <h4 class="authors-list__label type--label">{{ label }}</h4>
+  <ul class="authors-list">
+    {% for author in authors %}
+    <li class="authors-list__author">{{authorMacro(contributors[author], microcopy.author.alt, author)}}</li>
+    {% endfor %}
+  </ul>
+</section>
 {%- endmacro %}

--- a/site/_components/authors-list.njk
+++ b/site/_components/authors-list.njk
@@ -7,7 +7,8 @@
   @param {string} microcopy.author.alt - String to describe the author's photo
 
  #}-->
-{% from 'author.njk' import author as authorMacro %} {% macro authorsList(authors, contributors, microcopy) -%}
+{% from 'author.njk' import author as authorMacro %} {% macro authorsList(label, authors, contributors, microcopy) -%}
+<span class="authors-list__label type--label">{{ label }}</span>
 <ul class="authors-list">
   {% for author in authors %}
   <li class="authors-list__author">{{authorMacro(contributors[author], microcopy.author.alt, author)}}</li>

--- a/site/_components/authors-list.njk
+++ b/site/_components/authors-list.njk
@@ -8,12 +8,12 @@
 
  #}-->
 {% from 'author.njk' import author as authorMacro %} {% macro authorsList(label, authors, contributors, microcopy) -%}
-<section>
-  <h4 class="authors-list__label type--label">{{ label }}</h4>
-  <ul class="authors-list">
-    {% for author in authors %}
-    <li class="authors-list__author">{{authorMacro(contributors[author], microcopy.author.alt, author)}}</li>
-    {% endfor %}
-  </ul>
-</section>
+
+<h4 class="authors-list__label type--label">{{ label }}</h4>
+<ul class="authors-list">
+  {% for author in authors %}
+  <li class="authors-list__author">{{authorMacro(contributors[author], microcopy.author.alt, author)}}</li>
+  {% endfor %}
+</ul>
+
 {%- endmacro %}

--- a/site/_components/date-time.njk
+++ b/site/_components/date-time.njk
@@ -9,12 +9,14 @@
   @param {boolean} modifiers.inline - Use the inline modifier.
 #}-->
 {% macro dateTime(label, value, locale, options=undefined, modifiers={}) %}
+
+<h4 class="date-time__label type--label">{{ label }}</h4>
 <p class="date-time {{'date-time--inline' if modifiers.inline}}">
-  <span class="date-time__label type--label">{{ label }}</span>
   {% if modifiers.inline %}
   <time class="type--small" datetime="{{ value }}">{{ value | date(locale, options) }}</time>
   {% else %}
   <time class="type--h6" datetime="{{ value }}">{{ value | date(locale, options) }}</time>
   {% endif %}
 </p>
+
 {% endmacro %}

--- a/site/_layouts/article.njk
+++ b/site/_layouts/article.njk
@@ -19,7 +19,7 @@ layout: _wrapper
 
   <h1 class="article__header type--h2">{{title}}</h1>
 
-  {% if content | toc %}
+  {% if content | toc or authors %}
   <aside class="article__toc">{% if section == 'posts' %} {{ authorsList(microcopy.posted, authors, contributors, microcopy) }} {{ dateTime(microcopy.datePosted, page.date, locale.code, options={ year: 'numeric', month: 'long', day: 'numeric' }) }} {% elif section == 'case-studies' %} {{ appInfo(app) }} {% endif %} {{ tableOfContents(content, microcopy.toc.title, {title: microcopy.skip.toc, id: 'article'}) }}</aside>
   {% endif %} {% set topics = { label: microcopy.topics, items: tags } %}{% if section == 'case-studies' %}{% set updated = { label: microcopy.lastUpdated, date: page.date, locale: locale.code } %} {% endif %}
   <section class="article__body" id="article">

--- a/site/_layouts/article.njk
+++ b/site/_layouts/article.njk
@@ -20,7 +20,14 @@ layout: _wrapper
   <h1 class="article__header type--h2">{{title}}</h1>
 
   {% if content | toc or authors %}
-  <aside class="article__toc">{% if section == 'posts' %} {{ authorsList(microcopy.posted, authors, contributors, microcopy) }} {{ dateTime(microcopy.datePosted, page.date, locale.code, options={ year: 'numeric', month: 'long', day: 'numeric' }) }} {% elif section == 'case-studies' %} {{ appInfo(app) }} {% endif %} {{ tableOfContents(content, microcopy.toc.title, {title: microcopy.skip.toc, id: 'article'}) }}</aside>
+  <aside class="article__toc">
+    {% if section == 'posts' %}
+    <section class="article__section">{{ authorsList(microcopy.posted, authors, contributors, microcopy) }}</section>
+    <section class="article__section">{{ dateTime(microcopy.datePosted, page.date, locale.code, options={ year: 'numeric', month: 'long', day: 'numeric' }) }}</section>
+    {% elif section == 'case-studies' %}
+    <section class="article__section">{{ appInfo(app) }}</section>
+    {% endif %} {{ tableOfContents(content, microcopy.toc.title, {title: microcopy.skip.toc, id: 'article'}) }}
+  </aside>
   {% endif %} {% set topics = { label: microcopy.topics, items: tags } %}{% if section == 'case-studies' %}{% set updated = { label: microcopy.lastUpdated, date: page.date, locale: locale.code } %} {% endif %}
   <section class="article__body" id="article">
     <div class="article__content type">{{ content | safe }}</div>

--- a/site/_layouts/article.njk
+++ b/site/_layouts/article.njk
@@ -19,10 +19,8 @@ layout: _wrapper
 
   <h1 class="article__header type--h2">{{title}}</h1>
 
-  <aside class="article__info">{% if section == 'posts' %}{{ dateTime(microcopy.datePosted, page.date, locale.code, options={ year: 'numeric', month: 'long', day: 'numeric' }) }}{{ authorsList(authors, contributors, microcopy) }}{% elif section == 'case-studies' %}{{ appInfo(app) }}{% endif %}</aside>
-
   {% if content | toc %}
-  <aside class="article__toc">{{ tableOfContents(content, microcopy.toc.title, {title: microcopy.skip.toc, id: 'article'}) }}</aside>
+  <aside class="article__toc">{% if section == 'posts' %} {{ authorsList(microcopy.posted, authors, contributors, microcopy) }} {{ dateTime(microcopy.datePosted, page.date, locale.code, options={ year: 'numeric', month: 'long', day: 'numeric' }) }} {% elif section == 'case-studies' %} {{ appInfo(app) }} {% endif %} {{ tableOfContents(content, microcopy.toc.title, {title: microcopy.skip.toc, id: 'article'}) }}</aside>
   {% endif %} {% set topics = { label: microcopy.topics, items: tags } %}{% if section == 'case-studies' %}{% set updated = { label: microcopy.lastUpdated, date: page.date, locale: locale.code } %} {% endif %}
   <section class="article__body" id="article">
     <div class="article__content type">{{ content | safe }}</div>

--- a/site/en/_data/microcopy.yml
+++ b/site/en/_data/microcopy.yml
@@ -1,7 +1,7 @@
 topics: Topics
 lastUpdated: Last updated
 breadcrumbs: Back to ((t))
-posted: Posted by ((t))
+posted: Written by
 datePosted: Date posted
 more: Read more
 recommended: Recommended

--- a/site/sass/components/_app-info.scss
+++ b/site/sass/components/_app-info.scss
@@ -5,9 +5,11 @@
   $logo-size: pxRem(80px);
 
   display: flex;
+  margin-bottom: 2rem;
 
-  @include mq($bkpt-articles--2-cols) {
+  @include mq($bkpt-articles--3-cols) {
     flex-direction: column;
+    padding-left: 1.25rem;
   }
 
   &__logo {
@@ -22,7 +24,7 @@
     justify-content: center;
     margin-left: pxRem(24px);
 
-    @include mq($bkpt-articles--2-cols) {
+    @include mq($bkpt-articles--3-cols) {
       margin-left: 0;
       margin-top: pxRem(24px);
     }

--- a/site/sass/components/_app-info.scss
+++ b/site/sass/components/_app-info.scss
@@ -9,7 +9,6 @@
 
   @include mq($bkpt-articles--3-cols) {
     flex-direction: column;
-    padding-left: 1.25rem;
   }
 
   &__logo {

--- a/site/sass/components/_authors-list.scss
+++ b/site/sass/components/_authors-list.scss
@@ -1,13 +1,7 @@
 // Styles for authors list info used in news and stories.
 .authors-list {
-  $block-padding: 1.25rem;
-
   list-style: none;
   margin: 0.5rem 0 1.5rem;
-
-  @include mq($bkpt-articles--3-cols) {
-    padding-left: $block-padding;
-  }
 
   &__author {
     margin-bottom: 1rem;
@@ -16,9 +10,5 @@
   &__label {
     color: var(--grey-500);
     display: block;
-
-    @include mq($bkpt-articles--3-cols) {
-      padding-left: $block-padding;
-    }
   }
 }

--- a/site/sass/components/_authors-list.scss
+++ b/site/sass/components/_authors-list.scss
@@ -1,9 +1,24 @@
 // Styles for authors list info used in news and stories.
 .authors-list {
+  $block-padding: 1.25rem;
+
   list-style: none;
-  margin: pxRem(24px) 0;
+  margin: 0.5rem 0 1.5rem;
+
+  @include mq($bkpt-articles--3-cols) {
+    padding-left: $block-padding;
+  }
 
   &__author {
     margin-bottom: 1rem;
+  }
+
+  &__label {
+    color: var(--grey-500);
+    display: block;
+
+    @include mq($bkpt-articles--3-cols) {
+      padding-left: $block-padding;
+    }
   }
 }

--- a/site/sass/components/_date-time.scss
+++ b/site/sass/components/_date-time.scss
@@ -1,8 +1,16 @@
 // Styles for date-time label.
 
 .date-time {
+  margin-bottom: 2rem;
+
+  @include mq($bkpt-articles--3-cols) {
+    padding-left: 1.25rem;
+  }
+
   &__label {
+    color: var(--grey-500);
     display: block;
+    margin-bottom: 0.5rem;
   }
 
   &--inline & {

--- a/site/sass/components/_date-time.scss
+++ b/site/sass/components/_date-time.scss
@@ -3,10 +3,6 @@
 .date-time {
   margin-bottom: 2rem;
 
-  @include mq($bkpt-articles--3-cols) {
-    padding-left: 1.25rem;
-  }
-
   &__label {
     color: var(--grey-500);
     display: block;

--- a/site/sass/components/_toc.scss
+++ b/site/sass/components/_toc.scss
@@ -5,7 +5,7 @@
 .toc {
   $shadow-color: var(--grey-200);
   $block-padding: 1.25rem;
-  @include expandingNav($bkpt-tech-details--3-cols, 'toc', 1.75rem, $block-padding);
+  @include expandingNav($bkpt-tech-details--3-cols, 'toc', 1.75rem, 1.33rem);
 
   @include mq($bkpt-tech-details--3-cols) {
     position: sticky;
@@ -16,11 +16,11 @@
     }
 
     &__nav {
-      border-left: 2px solid $shadow-color;
+      border-left: 1px solid $shadow-color;
       margin-bottom: 2.5rem;
       max-height: calc(100vh - 11.5rem);
-      overflow-x: hidden;
-      overflow-y: auto;
+      // overflow-x: hidden;
+      // overflow-y: auto;
       padding-left: $block-padding;
       position: relative;
     }

--- a/site/sass/components/_toc.scss
+++ b/site/sass/components/_toc.scss
@@ -19,8 +19,6 @@
       border-left: 1px solid $shadow-color;
       margin-bottom: 2.5rem;
       max-height: calc(100vh - 11.5rem);
-      // overflow-x: hidden;
-      // overflow-y: auto;
       padding-left: $block-padding;
       position: relative;
     }

--- a/site/sass/components/_toc.scss
+++ b/site/sass/components/_toc.scss
@@ -16,7 +16,7 @@
     }
 
     &__nav {
-      border-left: 1px solid $shadow-color;
+      border-left: 2px solid $shadow-color;
       margin-bottom: 2.5rem;
       max-height: calc(100vh - 11.5rem);
       padding-left: $block-padding;

--- a/site/sass/components/_toc.scss
+++ b/site/sass/components/_toc.scss
@@ -3,7 +3,7 @@
 // Breakpoints are tied to tech-detail layout, so before reusing it some adjustments may be necessary.
 
 .toc {
-  $shadow-color: rgba(map-get($google-colors, 'grey-900'), 0.1);
+  $shadow-color: var(--grey-200);
   $block-padding: 1.25rem;
   @include expandingNav($bkpt-tech-details--3-cols, 'toc', 1.75rem, $block-padding);
 

--- a/site/sass/components/_toc.scss
+++ b/site/sass/components/_toc.scss
@@ -3,22 +3,25 @@
 // Breakpoints are tied to tech-detail layout, so before reusing it some adjustments may be necessary.
 
 .toc {
-  @include expandingNav($bkpt-tech-details--3-cols, 'toc', 1rem, 1rem);
+  $shadow-color: rgba(map-get($google-colors, 'grey-900'), 0.1);
+  $block-padding: 1.25rem;
+  @include expandingNav($bkpt-tech-details--3-cols, 'toc', 1.75rem, $block-padding);
 
   @include mq($bkpt-tech-details--3-cols) {
     position: sticky;
     top: 6.5rem;
 
     &__summary {
-      padding-left: 1.75rem;
+      padding-left: $block-padding;
     }
 
     &__nav {
+      border-left: 2px solid $shadow-color;
       margin-bottom: 2.5rem;
       max-height: calc(100vh - 11.5rem);
       overflow-x: hidden;
       overflow-y: auto;
-      padding-left: 1.75rem;
+      padding-left: $block-padding;
       position: relative;
     }
   }

--- a/site/sass/components/_tools.scss
+++ b/site/sass/components/_tools.scss
@@ -2,11 +2,10 @@
 // Breakpoints are tied to tech-detail layout, so before reusing it some adjustments may be necessary.
 
 .tools {
-  margin-bottom: 1rem;
+  margin-bottom: 2rem;
 
   @include mq($bkpt-tech-details--3-cols) {
-    margin-bottom: 1.5rem;
-    padding-left: 1.75rem;
+    padding-left: 1.25rem;
   }
 
   &__item-name {
@@ -15,7 +14,7 @@
 
   &__versions {
     list-style: none;
-    margin-top: 0.75rem;
+    margin-top: 1.25rem;
   }
 
   &__item {

--- a/site/sass/globals/extends/_anchor.scss
+++ b/site/sass/globals/extends/_anchor.scss
@@ -18,15 +18,18 @@
 
   &--page-nav {
     @include fontSetup(14px, 18px);
+    color: var(--grey-700);
     font-family: $font-body;
+    text-decoration: none;
+
+    &[data-active],
+    &:hover,
+    &:focus {
+      color: var(--grey-900);
+    }
 
     &[data-active] {
       text-shadow: 0 0 0 currentColor;
-    }
-
-    &:hover {
-      background-color: transparent;
-      text-decoration: none;
     }
 
     &:focus {
@@ -34,7 +37,7 @@
     }
 
     &:visited {
-      color: $anchor-color--default;
+      color: var(--grey-700);
     }
   }
 

--- a/site/sass/globals/extends/_expanding-nav.scss
+++ b/site/sass/globals/extends/_expanding-nav.scss
@@ -45,7 +45,7 @@
 
       &::after {
         background-color: var(--bkg);
-        border-left: 4px solid var(--blue-500);
+        border-left: 4px solid var(--blue-700);
         content: '';
         height: calc(100% + var(--padding) * 2);
         position: absolute;

--- a/site/sass/globals/extends/_type.scss
+++ b/site/sass/globals/extends/_type.scss
@@ -71,8 +71,8 @@
 
   &--small {
     @extend %type--base;
-
     @include fontSetup(12px, 16px, 400);
+    color: var(--grey-700);
   }
 
   &--quote {
@@ -91,7 +91,7 @@
   }
 
   &--label {
-    @include fontSetup(11px, 16px, 600);
+    @include fontSetup(12px, 16px, 600);
     color: var(--grey-900);
     text-rendering: optimizeLegibility;
     text-transform: uppercase;

--- a/site/sass/layouts/_article.scss
+++ b/site/sass/layouts/_article.scss
@@ -5,7 +5,7 @@
 
 .article {
   $default-eyebrow-color: map-get($google-colors, 'blue-600');
-  --col-padding: #{pxRem(28px)};
+  --col-padding: 1.5rem;
 
   display: grid;
 
@@ -132,25 +132,6 @@
     }
   }
 
-  &__info {
-    margin-bottom: pxRem(24px);
-    padding: 0 var(--col-padding);
-
-    @include mq($bkpt-articles--2-cols) {
-      background-color: var(--grey-100);
-      border-bottom: 1px solid var(--grey-300);
-      grid-column: 1 / span 1;
-      grid-row: 3 / span 3;
-      margin-bottom: 0;
-      padding-top: var(--col-padding);
-    }
-
-    @include mq($bkpt-articles--3-cols) {
-      grid-column: 2 / span 1;
-      grid-row: 3 / span 2;
-    }
-  }
-
   &__toc {
     margin-bottom: pxRem(48px);
     padding: 0 var(--col-padding);
@@ -162,8 +143,6 @@
     }
 
     @include mq($bkpt-articles--3-cols) {
-      background-color: var(--grey-100);
-      border-bottom: 1px solid var(--grey-300);
       grid-column: 4 / span 1;
       grid-row: 3 / span 2;
       margin-bottom: 0;

--- a/site/sass/layouts/_article.scss
+++ b/site/sass/layouts/_article.scss
@@ -5,6 +5,7 @@
 
 .article {
   $default-eyebrow-color: map-get($google-colors, 'blue-600');
+  $block-padding: 1.25rem;
   --col-padding: 1.5rem;
 
   display: grid;
@@ -147,6 +148,12 @@
       grid-row: 3 / span 2;
       margin-bottom: 0;
       padding-top: var(--col-padding);
+    }
+  }
+
+  &__section {
+    @include mq($bkpt-articles--3-cols) {
+      padding-left: $block-padding;
     }
   }
 

--- a/site/sass/layouts/_tech-detail.scss
+++ b/site/sass/layouts/_tech-detail.scss
@@ -4,7 +4,7 @@
 .tech-detail {
   $root: &;
   $spacing: clamp(3.75rem, 7.8125vw, 5rem);
-  $inline-padding: 1.75rem;
+  $inline-padding: 1.5rem;
   $block-padding: 2.5rem;
 
   // TODO check breakpoints, spacing distribution when sample content is loaded.


### PR DESCRIPTION
Added Right Sidebar design for Article Detail Pages (technical, news, stories).

Right Sidebar notes:
1. I believe all `type--small` should have the --grey-700 color instead of the --grey-900
2. Added border-left to TOC navigation
3. Added a few minor spacing tweaks
4. I'll probably going to change this variable `$bkpt-articles--3-cols` since we only have 2 columns for News/Stories article pages. Will do this once I'm done with all components for each article page.

- Resolves #345 
