### PR TITLE
💎(site) Center main subnav on large screens

### DIFF
--- a/site/sass/components/_nav.scss
+++ b/site/sass/components/_nav.scss
@@ -211,14 +211,14 @@
       border-top: 1px solid var(--grey-300);
       display: flex;
       flex-wrap: wrap;
-      left: -0.75rem;
+      justify-content: center;
+      left: 0;
       list-style: none;
       margin: unset;
-      padding: 0 calc(4.25rem + 185px);
-      padding-right: 1rem;
+      padding: 0 1rem;
       position: absolute;
       top: 4rem;
-      width: calc(100vw + 0.75rem);
+      width: 100vw;
       z-index: 100;
 
       &-item {


### PR DESCRIPTION
Subnav is still positioned based on left-aligned nav. Now that main nav is centered, this centers the subnav, too
