### PR TITLE
🐛 Fix missing social share and apple touch images

### DIFF
--- a/lib/transforms/google-storage-images.js
+++ b/lib/transforms/google-storage-images.js
@@ -117,8 +117,15 @@ module.exports = async function postHTMLGoogleStorageImage(tree) {
     }
   });
 
+  // Link tags
   tree.match({ attrs: { href: /^(ix:\/\/)/ } }, (node) => {
     node.attrs.href = node.attrs.href.replace(/^(ix:\/\/)/, 'https://chromeos-dev.imgix.net/');
+    return node;
+  });
+
+  // OG tags
+  tree.match({ attrs: { property: 'og:image', content: /^(ix:\/\/)/ } }, (node) => {
+    node.attrs.content = node.attrs.content.replace(/^(ix:\/\/)/, 'https://chromeos-dev.imgix.net/');
     return node;
   });
 

--- a/lib/transforms/google-storage-images.js
+++ b/lib/transforms/google-storage-images.js
@@ -119,19 +119,19 @@ module.exports = async function postHTMLGoogleStorageImage(tree) {
 
   // Link tags
   tree.match({ attrs: { href: /^(ix:\/\/)/ } }, (node) => {
-    node.attrs.href = node.attrs.href.replace(/^(ix:\/\/)/, 'https://chromeos-dev.imgix.net/');
+    node.attrs.href = node.attrs.href.replace(/^(ix:\/\/)/, 'https://chromeos-dev.imgix.net/') + '?auto=format,compress';
     return node;
   });
 
   // OG tags
   tree.match({ attrs: { property: 'og:image', content: /^(ix:\/\/)/ } }, (node) => {
-    node.attrs.content = node.attrs.content.replace(/^(ix:\/\/)/, 'https://chromeos-dev.imgix.net/');
+    node.attrs.content = node.attrs.content.replace(/^(ix:\/\/)/, 'https://chromeos-dev.imgix.net/') + '?auto=format,compress';
     return node;
   });
 
   // All sourceset tags
   tree.match({ attrs: { srcset: /^(ix:\/\/)/ } }, (node) => {
-    node.attrs.srcset = node.attrs.srcset.replace(/^(ix:\/\/)/, 'https://chromeos-dev.imgix.net/');
+    node.attrs.srcset = node.attrs.srcset.replace(/^(ix:\/\/)/, 'https://chromeos-dev.imgix.net/') + '?auto=format,compress';
     return node;
   });
 

--- a/site/_data/eleventyComputed.js
+++ b/site/_data/eleventyComputed.js
@@ -238,7 +238,7 @@ module.exports = {
       og.push([
         {
           property: 'image',
-          content: 'ix://icons/social.png',
+          content: 'ix://icons/social-2022.png',
         },
         {
           property: 'image:alt',

--- a/site/_layouts/_wrapper.njk
+++ b/site/_layouts/_wrapper.njk
@@ -9,7 +9,7 @@
     <meta name="Description" content="{{ metadesc }}" />
     <meta name="theme-color" content="#1a73e8" />
     <link rel="icon" type="image/png" href="ix://icons/favicon.png" />
-    <link rel="apple-touch-icon" href="ix://icons/pwa/icon-192x192.png" />
+    <link rel="apple-touch-icon" href="/images/icons/pwa/icon-192x192.png" />
 
     {% for prop in og %}
     <meta property="og:{{prop.property}}" content="{{prop.content}}" />


### PR DESCRIPTION
* Transforms Open Graph meta image tags if they're hosted on our CDN
* Updates Social Share image to new-for-2022 image
* Fixes Apple Touch icon (now points to correct image)
* Ensures all transformed images include auto formatting and compression