### PR TITLE
🐛(build) Fix custom markdown linting

### DIFF
--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -70,10 +70,9 @@ exports.plugins = [
     { no: 'stupid' },
     { no: 'moronic' },
     { no: '(-|\w)tard(ed)?' }
-  ]],
+  ]]],
 
   // Custom
   [require('./lib/linting/content-models.js'), [2]],
   [require('./lib/linting/md-name-lint'), [2]],
-],
 ];

--- a/lib/linting/schemas/core.js
+++ b/lib/linting/schemas/core.js
@@ -17,7 +17,7 @@
 const tags = require('./definitions/tags');
 
 module.exports = {
-  $id: 'https://example.com/person.schema.json',
+  $id: 'https://chromeos.dev/core.schema.json',
   $schema: 'http://json-schema.org/draft-07/schema#',
   title: 'Core Schema',
   type: 'object',
@@ -28,12 +28,12 @@ module.exports = {
       type: 'string',
       description: 'Article title',
       minLength: 5,
-      maxLength: 100,
+      maxLength: 115,
     },
     metadesc: {
       type: 'string',
       description: 'Metadesc of article',
-      minLength: 5,
+      minLength: 35,
       maxLength: 200,
     },
     date: {

--- a/lib/linting/schemas/definitions/app.js
+++ b/lib/linting/schemas/definitions/app.js
@@ -21,7 +21,7 @@ module.exports = {
   definition: {
     type: 'object',
     description: 'App information',
-    required: ['name', 'logo', 'company'],
+    required: ['name', 'logo'],
     additionalProperties: false,
     properties: {
       name: {

--- a/lib/linting/schemas/definitions/technical-hero.js
+++ b/lib/linting/schemas/definitions/technical-hero.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = {
+  property: {
+    $ref: '#/definitions/technical-hero',
+  },
+  definition: {
+    type: 'object',
+    description: 'Technical hero image',
+    required: ['image'],
+    additionalProperties: false,
+    properties: {
+      image: {
+        type: 'object',
+        description: 'Images for the hero',
+        required: ['top', 'bottom'],
+        additionalProperties: false,
+        properties: {
+          top: {
+            type: 'string',
+            format: 'uri-reference',
+            description: 'URL to the image to use when displayed large, cropped to the top',
+          },
+          bottom: {
+            type: 'string',
+            format: 'uri-reference',
+            description: 'URL to the image to use when displayed small, cropped to the bottom',
+          },
+        },
+      },
+    },
+  },
+};

--- a/lib/linting/schemas/definitions/theme.js
+++ b/lib/linting/schemas/definitions/theme.js
@@ -39,9 +39,22 @@ module.exports = {
         minLength: 1,
       },
       background: {
-        type: 'string',
-        description: 'URL to background pattern to use',
-        minLength: 10,
+        type: 'object',
+        description: 'URIs for background images to use',
+        required: ['top', 'bottom'],
+        additionalProperties: false,
+        properties: {
+          top: {
+            type: 'string',
+            format: 'uri-reference',
+            description: 'URL to the image to use when displayed large, cropped to the top',
+          },
+          bottom: {
+            type: 'string',
+            format: 'uri-reference',
+            description: 'URL to the image to use when displayed small, cropped to the bottom',
+          },
+        },
       },
     },
   },

--- a/lib/linting/schemas/technical.js
+++ b/lib/linting/schemas/technical.js
@@ -19,7 +19,7 @@ const clone = require('lodash.clonedeep');
 const core = clone(require('./core'));
 const tools = require('./definitions/tools');
 const resources = require('./definitions/resources');
-const hero = require('./definitions/hero');
+const hero = require('./definitions/technical-hero');
 
 module.exports = {
   $merge: {
@@ -38,7 +38,7 @@ module.exports = {
       definitions: {
         tools: tools.definition,
         resources: resources.definition,
-        hero: hero.definition,
+        'technical-hero': hero.definition,
       },
     },
   },

--- a/site/en/games/index.md
+++ b/site/en/games/index.md
@@ -1,6 +1,6 @@
 ---
 title: Games on Chrome OS
-metadesc: Create games for Chrome OS
+metadesc: Adapt your Android and web games for Chrome OS
 hero:
   image:
     top: ix://landings/heroes/games.svg

--- a/site/en/posts/chromeos-100.md
+++ b/site/en/posts/chromeos-100.md
@@ -3,7 +3,7 @@ title: 'Celebrating Chrome OS 100: Recapping how we’ve grown with developers o
 metadesc: In honor of the 100th stable channel release on Chrome OS, we’ve highlighted some new announcements and the best features for developers to date.
 tags:
   - announcement
-  - trends
+  - trend
   - technical
   - android
   - web

--- a/site/es/games/index.md
+++ b/site/es/games/index.md
@@ -1,6 +1,6 @@
 ---
 title: Juegos en Chrome OS
-metadesc: Crea juegos para Chrome OS.
+metadesc: Adapta tus juegos de Android y web para Chrome OS.
 hero:
   image:
     top: ix://landings/heroes/games.svg

--- a/tests/schemas/posts.js
+++ b/tests/schemas/posts.js
@@ -43,7 +43,7 @@ test('Required Fields', (t) => {
 test('Optional Fields', (t) => {
   const input = {
     title: 'Large screen Android',
-    metadesc: 'This is the new Android content.',
+    metadesc: 'This is the new Android content. Its great.',
     authors: ['allanl'],
     hero: {
       image: '/images/hero/awesome-fun-time.jpg',
@@ -410,3 +410,5 @@ test('Fields Validation', (t) => {
   t.is(isValid, false);
   t.deepEqual(t.context.validate.errors, featuredErrors);
 });
+
+// TODO - Add tests for theme

--- a/tests/schemas/stories.js
+++ b/tests/schemas/stories.js
@@ -30,7 +30,7 @@ test.beforeEach((t) => {
 test('Required Fields', (t) => {
   const input = {
     title: 'Large screen Android',
-    metadesc: 'This is the new Android content.',
+    metadesc: 'This is the new Android content. Its great.',
     date: '2019-10-24T00:00:00.000Z',
     app: {
       name: 'Awesome Fun Time',
@@ -46,7 +46,7 @@ test('Required Fields', (t) => {
 test('Optional Fields', (t) => {
   const input = {
     title: 'Large screen Android',
-    metadesc: 'This is the new Android content.',
+    metadesc: 'This is the new Android content. Its great.',
     app: {
       name: 'Awesome Fun Time',
       logo: '/images/logos/awesome-fun-time.jpg',
@@ -165,7 +165,7 @@ test('Missing Fields', (t) => {
 test('Extra Fields', (t) => {
   const input = {
     title: 'Large screen Android',
-    metadesc: 'This is the new Android content.',
+    metadesc: 'This is the new Android content. Its great.',
     date: '2019-10-24T00:00:00.000Z',
     app: {
       name: 'Awesome Fun Time',
@@ -266,13 +266,6 @@ test('Field Validation', (t) => {
       schemaPath: '#/definitions/app/required',
       params: { missingProperty: 'logo' },
       message: "should have required property 'logo'",
-    },
-    {
-      keyword: 'required',
-      dataPath: '.app',
-      schemaPath: '#/definitions/app/required',
-      params: { missingProperty: 'company' },
-      message: "should have required property 'company'",
     },
     {
       keyword: 'type',
@@ -413,13 +406,6 @@ test('Field Validation', (t) => {
       schemaPath: '#/definitions/app/required',
       params: { missingProperty: 'logo' },
       message: "should have required property 'logo'",
-    },
-    {
-      keyword: 'required',
-      dataPath: '.app',
-      schemaPath: '#/definitions/app/required',
-      params: { missingProperty: 'company' },
-      message: "should have required property 'company'",
     },
     {
       keyword: 'additionalProperties',

--- a/tests/schemas/technical.js
+++ b/tests/schemas/technical.js
@@ -29,7 +29,7 @@ test.beforeEach((t) => {
 test('Required Fields', (t) => {
   const input = {
     title: 'Large screen Android',
-    metadesc: 'This is the new Android content.',
+    metadesc: 'This is the new Android content. Its great.',
     date: '2019-10-24T00:00:00.000Z',
   };
   const valid = t.context.validate(input);
@@ -40,7 +40,7 @@ test('Required Fields', (t) => {
 test('Optional Fields', (t) => {
   const input = {
     title: 'Large screen Android',
-    metadesc: 'This is the new Android content.',
+    metadesc: 'This is the new Android content. Its great.',
     weight: -1,
     date: '2019-10-24T00:00:00.000Z',
     tools: [
@@ -126,7 +126,7 @@ test('Missing Fields', (t) => {
 test('Extra Fields', (t) => {
   const input = {
     title: 'Large screen Android',
-    metadesc: 'This is the new Android content.',
+    metadesc: 'This is the new Android content. Its great.',
     date: '2019-10-24T00:00:00.000Z',
     banana: 'foo',
   };
@@ -188,15 +188,15 @@ test('Fields Validation', (t) => {
       keyword: 'maxLength',
       dataPath: '.title',
       schemaPath: '#/properties/title/maxLength',
-      params: { limit: 100 },
-      message: 'should NOT be longer than 100 characters',
+      params: { limit: 115 },
+      message: 'should NOT be longer than 115 characters',
     },
     {
       keyword: 'minLength',
       dataPath: '.metadesc',
       schemaPath: '#/properties/metadesc/minLength',
-      params: { limit: 5 },
-      message: 'should NOT be shorter than 5 characters',
+      params: { limit: 35 },
+      message: 'should NOT be shorter than 35 characters',
     },
     {
       keyword: 'format',
@@ -280,3 +280,5 @@ test('Fields Validation', (t) => {
   t.is(valid, false);
   t.deepEqual(t.context.validate.errors, errors);
 });
+
+// TODO - Add tests for technical hero


### PR DESCRIPTION
Custom markdown linting, especially our content model linting, was not being called properly. This fixes that, and ensures that any outstanding linting problems are resolved.

There are some tests to be written for `theme` and `technical-hero`, but I'm OK merging this for now without them as I don't expect much churn there and we need a larger story around testing