### PR TITLE
🐛(site) Fix form success event firing

### DIFF
--- a/site/js/components/form.js
+++ b/site/js/components/form.js
@@ -353,7 +353,7 @@ export class Form {
     window.tracking.sendEvent('form_submit_success', {
       form_id: this.id_,
       form_referrer: referrer ? referrer.toString() : '',
-    });
+    })();
 
     this.elem_.parentNode.insertBefore(holder, this.elem_);
   }


### PR DESCRIPTION
`tracking.sendEvent` returns a function so it can be passed directly to event listeners, but when calling it one-off, it then needs to be called