### PR TITLE
🐛(site) Fix Case Study hero image and site title

### DIFF
--- a/site/_data/eleventyComputed.js
+++ b/site/_data/eleventyComputed.js
@@ -126,6 +126,7 @@ module.exports = {
   nav: l10nFallback('nav'),
   cookies: l10nFallback('cookieDisclaimer'),
   search: l10nFallback('search'),
+  microcopy: l10nFallback('microcopy'),
   showNewsletter: (data) => (l10nFallback('hideNewsletter')(data) ? false : 'show'),
   subscribe: l10nFallback('newsletter.subscribe'),
   og: (data) => {

--- a/site/_layouts/_wrapper.njk
+++ b/site/_layouts/_wrapper.njk
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
 
-    <title>{% if title %}{{ title }} | {% endif %}chromeOS.dev</title>
+    <title>{% if title %}{{ title }} | {% endif %}{{ microcopy.title }}</title>
     <meta name="Description" content="{{ metadesc }}" />
     <meta name="theme-color" content="#1a73e8" />
     <link rel="icon" type="image/png" href="ix://icons/favicon.png" />

--- a/site/_layouts/article.njk
+++ b/site/_layouts/article.njk
@@ -7,7 +7,9 @@ layout: _wrapper
 <article class="article">
   <div class="article__hero">{{skipLink(microcopy.skip.content, 'article')}} {{ heroArticle(section, locale, parent, microcopy, tags[1], title, hero, theme, app) }}</div>
   {% if section == 'case-studies' %}
-  <div class="wrapper--padded wrapper--full-bleed article__hero-image-wrapper"></div>
+  <div class="wrapper--padded wrapper--full-bleed article__hero-image-wrapper">
+    <img src="{{hero.image}}" alt="{{hero.alt}}" class="article__hero-image" />
+  </div>
   {% endif %} {% if section == 'posts' and hero.youtube %}
   <div class="wrapper--padded wrapper--full-bleed article__hero-image-wrapper">
     <div class="article__video">

--- a/site/en/_data/microcopy.yml
+++ b/site/en/_data/microcopy.yml
@@ -1,3 +1,4 @@
+title: ChromeOS for developers
 topics: Topics
 lastUpdated: Last updated
 breadcrumbs: Back to ((t))

--- a/site/es/_data/microcopy.yml
+++ b/site/es/_data/microcopy.yml
@@ -1,3 +1,4 @@
+title: ChromeOS para desarrolladores
 topics: Temas
 lastUpdated: Última actualización
 breadcrumbs: Volver a ((t))


### PR DESCRIPTION
* Case study hero image was accidentally removed at some point, this restores it
* Site title update to `ChromeOS for developers`