### PR TITLE
🐎(build) Install function deps directly in deploy

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -50,11 +50,24 @@ jobs:
         with:
           name: site
           path: public
+
+      # Needed for functions deploy
       - name: Upload search index state
         uses: actions/upload-artifact@v1
+        if: github.ref == 'refs/heads/main'
         with:
           name: indexes
           path: functions/indexes
+      - name: Install functions dependencies
+        if: github.ref == 'refs/heads/main'
+        run: |
+          npm ci --prefix functions
+      - name: Upload functions dependencies
+        uses: actions/upload-artifact@v1
+        if: github.ref == 'refs/heads/main'
+        with:
+          name: functions-deps
+          path: functions/node_modules
 
   #########################
   ## Preview Deploy
@@ -98,6 +111,11 @@ jobs:
         with:
           name: indexes
           path: functions/indexes
+      - name: Download functions dependencies
+        uses: actions/download-artifact@v1
+        with:
+          name: functions-deps
+          path: functions/node_modules
       - name: Deploy Hosting
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -58,16 +58,6 @@ jobs:
         with:
           name: indexes
           path: functions/indexes
-      - name: Install functions dependencies
-        if: github.ref == 'refs/heads/main'
-        run: |
-          npm ci --prefix functions
-      - name: Upload functions dependencies
-        uses: actions/upload-artifact@v1
-        if: github.ref == 'refs/heads/main'
-        with:
-          name: functions-deps
-          path: functions/node_modules
 
   #########################
   ## Preview Deploy
@@ -111,11 +101,14 @@ jobs:
         with:
           name: indexes
           path: functions/indexes
-      - name: Download functions dependencies
-        uses: actions/download-artifact@v1
+      - name: Setup Node
+        uses: actions/setup-node@v1
         with:
-          name: functions-deps
-          path: functions/node_modules
+          node-version: 14
+      - name: Install functions dependencies
+        if: github.ref == 'refs/heads/main'
+        run: |
+          npm ci --prefix functions
       - name: Deploy Hosting
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:


### PR DESCRIPTION
Uploading and downloading dependencies using artifacts is way slower than just installing directly.
