### PR TITLE
📝(content) Update Pointer Icon documentation

### DIFF
--- a/site/en/android/pointer-styling.md
+++ b/site/en/android/pointer-styling.md
@@ -16,14 +16,11 @@ Android users come to your app from all different types of form factors i.e., ph
 Users are familiar with different conventions for interacting with different types of objects on large screen devices. Android out of the box luckily provides developers with some of the most common cursor icons that users are familiar with. Adding in some of these system default cursor icons is easy. Let's take a look at the following Kotlin snippet:
 
 ```kotlin {title="Kotlin" .code-figure}
-myView.setOnHoverListener { view, _ ->
-      view.pointerIcon =
+myView.pointerIcon =
          PointerIcon.getSystemIcon(applicationContext, PointerIcon.TYPE_HAND)
-      false // Listener did not consume the event.
-}
 ```
 
-`myView` is the view that will be set to a pointer icon under certain conditions. The condition that is demonstrated is a hover state in this scenario. This is when the mouse is hovering over a view. (In other scenarios, it may be desirable to have a waiting icon when processing or a crosshair when playing a game). Here the `setOnHoverListener` is used to listen for when the pointer has entered that hover state and then act upon that event. Inside the event listener, `view.pointerIcon` is called to set the pointer icon for that particular view. An existing system icon is used to set the pointers icon. There are several system icons already built into Android and a full list can be found at the [bottom of this page](/{{locale.code}}/android/pointer-styling#system-default-cursors). The `TYPE_HAND` icon was used which will show a closed hand with the index finger extended.
+`myView` is the view that will change the pointer icon when the mouse is hovering over it. (In other scenarios, it may be desirable to have a waiting icon when processing or a crosshair when playing a game). `myView.pointerIcon` is called to set the pointer icon for that particular view. An existing system icon is used to set the pointers icon. There are several system icons already built into Android and a full list can be found at the [bottom of this page](/{{locale.code}}/android/pointer-styling#system-default-cursors). The `TYPE_HAND` icon was used which will show a closed hand with the index finger extended.
 
 ## Using your own special cursor
 

--- a/site/es/android/pointer-styling.md
+++ b/site/es/android/pointer-styling.md
@@ -16,14 +16,11 @@ Los usuarios de Android acceden a su aplicación desde todos los diferentes tipo
 Los usuarios están familiarizados con diferentes convenciones para interactuar con diferentes tipos de objetos en dispositivos de pantalla grande. Android, sin necesidad de agregar ningún cambio, ofrece a los desarrolladores algunos de los iconos de cursor más comunes con los que los usuarios están familiarizados. Agregar algunos de estos iconos de cursor predeterminados del sistema es fácil. Echemos un vistazo al siguiente fragmento de Kotlin:
 
 ```kotlin {title="Kotlin" .code-figure}
-myView.setOnHoverListener { view, _ ->
-      view.pointerIcon =
+myView.pointerIcon =
          PointerIcon.getSystemIcon(applicationContext, PointerIcon.TYPE_HAND)
-      false // Listener did not consume the event.
-}
 ```
 
-`myView` es la vista que será asociada con cierto ícono de puntero bajo ciertas circumstancias. La condición utilizada para demostrar en este escenario es el estado al desplazarse sobre la vista (hover) . (En otros escenarios, puede ser recomendable tener un ícono de espera mientras la aplicación esté haciendo una tarea de procesamiento o un punto de mira en el caso de juegos). Aquí se utiliza `setOnHoverListener` para escuchar cuando el puntero se desliza sobre la vista y entonces actuar en ese evento. Dentro del método que escucha por el evento , se llama a `view.pointerIcon` para actualizar el ícono para esa vista en particular. Un ícono existente del sistema se utiliza para este caso. En Android existen varios íconos del sistema ya integrados y se puede encontrar una lista completa [al final de esta página](/{{locale.code}}/android/pointer-styling#system-default-cursors). En el ejemplo se uso el icono `TYPE_HAND` que muestra una mano cerrada con el dedo indice extendido.
+`myView` es la vista que será asociada con cierto ícono de puntero durante un evento de desplazarse sobre esta vista (hover). (En otros escenarios, puede ser recomendable tener un ícono de espera mientras la aplicación esté haciendo una tarea de procesamiento o un punto de mira en el caso de juegos). Llama a `myView.pointerIcon` para actualizar el ícono para esa vista en particular. Un ícono existente del sistema se utiliza para este caso. En Android existen varios íconos del sistema ya integrados y se puede encontrar una lista completa [al final de esta página](/{{locale.code}}/android/pointer-styling#system-default-cursors). En el ejemplo se uso el icono `TYPE_HAND` que muestra una mano cerrada con el dedo indice extendido.
 
 ## Usando tu propio cursor especial
 


### PR DESCRIPTION
The pointer icon docs recommended watching for onHover events. This no longer works in Android 14. Talking with Android eng, it turns out that setPointerIcon automatically handles onHover. Updating docs.

Also updated the spanish version.