### PR TITLE
DOM text reinterpreted as HTML {Patch}

### DIFF
--- a/site/js/components/form.js
+++ b/site/js/components/form.js
@@ -354,9 +354,9 @@ export class Form {
     const holder = document.createElement('p');
 
     if (referrer !== false) {
-      holder.innerHTML = content.replace(/\[\[([\w|\s]*?)\]\]/, `<a href="${referrer.href}">$1</a>`);
+      holder.innerText = content.replace(/\[\[([\w|\s]*?)\]\]/, `<a href="${referrer.href}">$1</a>`);
     } else {
-      holder.innerHTML = content.replace(/\s*\[\[([\w|\s]*?)\]\]\s*\W/, '');
+      holder.innerText = content.replace(/\s*\[\[([\w|\s]*?)\]\]\s*\W/, '');
     }
 
     holder.classList.add('message', 'form__message', 'message--tip');


### PR DESCRIPTION
Issue link: https://issuetracker.google.com/issues/330971377

By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML. Always be cautious when dealing with user input or dynamic content to prevent security risks.
