### PR TITLE
🐛(site) Details in Safari and dark-mode section nav title

### DIFF
--- a/site/src/components/Release.astro
+++ b/site/src/components/Release.astro
@@ -222,15 +222,26 @@ if (single) {
     padding-top: 0;
   }
 
+  details {
+    appearance: none;
+    position: relative;
+  }
+
   summary {
     list-style: none;
     display: grid;
     grid-template-columns: 1fr 1rem;
     gap: 0;
+
+    &::-webkit-details-marker {
+      display: none;
+    }
   }
 
   .details-marker {
     fill: currentColor;
+    height: 1rem;
+    width: 1rem;
 
     [open] & {
       transform: rotate(90deg);

--- a/site/src/components/SectionNav.svelte
+++ b/site/src/components/SectionNav.svelte
@@ -74,9 +74,7 @@
 
     &--title {
       :global([data-theme='dark']) & {
-        @container style(--inline-subnav: 1) {
-          color: var(--global-background);
-        }
+        color: var(--global-background);
       }
     }
 


### PR DESCRIPTION
* Fixes styling for Release landing page's `details` in Safari
* Fixes dark mode section nav header not working without style queries