### PR TITLE
🐛(site) Fix step reinforcements and content overflow

### DIFF
--- a/site/src/layouts/views/Tutorial.astro
+++ b/site/src/layouts/views/Tutorial.astro
@@ -104,6 +104,8 @@ if (!isNaN(task)) {
 
 // console.log(tutorial.tasks[task]);
 
+console.log(outro);
+
 let title;
 let eyebrow;
 if (intro) {
@@ -203,16 +205,28 @@ if (intro) {
               client:only="svelte"
             />
             <ul class="reinforcements">
-              {tutorial.outro.next.steps.map((g, i) => (
-                <Reinforcement
-                  tutorial={slugify(tutorial.title)}
-                  task={slugify(tutorial.tasks[task].title)}
-                  step={i}
-                  client:load
-                >
-                  <Text body={g} inline={true} wrapped={false} />
-                </Reinforcement>
-              ))}
+              {tutorial?.tasks[task]?.reinforcement &&
+                tutorial?.tasks[task]?.reinforcement.map((g, i) => (
+                  <Reinforcement
+                    tutorial={slugify(tutorial.title)}
+                    task={slugify(tutorial.tasks[task].title)}
+                    step={i}
+                    client:load
+                  >
+                    <Text body={g} inline={true} wrapped={false} />
+                  </Reinforcement>
+                ))}
+              {outro &&
+                tutorial.outro.next.steps.map((g, i) => (
+                  <Reinforcement
+                    tutorial={slugify(tutorial.title)}
+                    task={slugify(tutorial.tasks[task].title)}
+                    step={i}
+                    client:load
+                  >
+                    <Text body={g} inline={true} wrapped={false} />
+                  </Reinforcement>
+                ))}
             </ul>
           </section>
         </>
@@ -397,6 +411,7 @@ if (intro) {
     display: flex;
     flex-direction: column;
     gap: 2rem;
+    overflow-x: hidden;
   }
 
   .pagination {

--- a/site/src/layouts/views/Tutorial.astro
+++ b/site/src/layouts/views/Tutorial.astro
@@ -104,8 +104,6 @@ if (!isNaN(task)) {
 
 // console.log(tutorial.tasks[task]);
 
-console.log(outro);
-
 let title;
 let eyebrow;
 if (intro) {
@@ -411,7 +409,7 @@ if (intro) {
     display: flex;
     flex-direction: column;
     gap: 2rem;
-    overflow-x: hidden;
+    overflow-x: clip;
   }
 
   .pagination {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Reinforcements were always pulling from outro instead of their steps. Fixed, along with step X overflow 

<!-- Please include a description here describing "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/chromeos/chromeos.dev/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ensure your PR title matches the following format: 🐛|🆕|📝|♻️|💎|🐎|📌(scope) subject. Subject must be written in English, start with a capital letter, can contain letters, spaces, numbers, dashes, commas, and dots, and must not end with a period or extra whitespace. See our [commit convention](https://github.com/chromeos/chromeos.dev/blob/main/.github/commit-convention.md) for emoji descriptions, scopes and their descriptions, and full examples.
